### PR TITLE
Add Mobile Flight Recorder workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `mobile-flight-recorder` workflow for end-of-session handoffs, including `MOBILE_AGENCY_CONTEXT.md` schema, MRECALL/Mobile Memory integration, tool-agnostic resume prompt, docs, and wiki guidance.
 - `device-proof-report` workflow announcement and wiki guidance so users know how to turn Mobile MCP screenshots, actions, assertions, logs, and accessibility notes into `DEVICE_QA_REPORT.md`.
 - Performance Loop guide for startup, ANR, memory leaks, frame drops, battery, network, app size, slow screens, and regression monitoring, including a deterministic `PERFORMANCE_AUDIT_REPORT.md` format.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The complete AI dev team for mobile engineers.**
 
-19 personality-driven agents · 52 composable skills · 15 end-to-end workflows
+19 personality-driven agents · 52 composable skills · 16 end-to-end workflows
 Android · iOS · Flutter · React Native · Kotlin Multiplatform · Unity · Unreal
 
 [![npm](https://img.shields.io/npm/v/mobile-ai-agents?color=CB3837&label=npm)](https://www.npmjs.com/package/mobile-ai-agents)
@@ -131,7 +131,7 @@ Platform Plugins: Android · iOS · Flutter · React Native · Kotlin Multiplatf
 | Testing | Unit tests, UI tests, accessibility, PRD checks, device QA | `/mobile-mcp-qa`, TDD skills, accessibility audit |
 | Release | CI/CD, signing, release notes, rollout, store checklist | `@PIPELINE`, `@SCRIBE`, `/release-prep` |
 | Growth | ASO, store listing, screenshots, monetization | `@LAUNCHPAD`, `/store-listing` |
-| Maintenance | Crash triage, context memory, issue planning, regression checks | `@CRASHER`, Mobile Memory, issue-to-agent workflow |
+| Maintenance | Crash triage, context memory, issue planning, regression checks | `@CRASHER`, Mobile Memory, Mobile Flight Recorder, issue-to-agent workflow |
 
 Security and performance are built into the loop before release. They are not optional cleanup steps.
 
@@ -215,7 +215,7 @@ Not sure where to begin? Pick your situation:
 |---|---|---|
 | Platform knowledge | Generic | Android · iOS · Flutter · React Native · Unity · Unreal |
 | Agent personalities | None | 19 named specialists with opinions |
-| Real workflows | No | 15 end-to-end processes |
+| Real workflows | No | 16 end-to-end processes |
 | Real examples | Toy pseudocode | Production code input/output pairs |
 | Installable | Copy-paste | `npx mobile-ai-agents install` |
 | Severity levels | None | CRITICAL · WARNING · INFO |
@@ -327,7 +327,7 @@ Not sure where to begin? Pick your situation:
 
 ## Workflows
 
-15 end-to-end processes that chain agents and skills together.
+16 end-to-end processes that chain agents and skills together.
 
 | Workflow | What It Covers |
 |---|---|
@@ -340,6 +340,7 @@ Not sure where to begin? Pick your situation:
 | `perf-sprint` | Baseline → /perf-audit → fix → re-measure → document |
 | `game-level` | Design doc → FORGE/UNREAL → /shader-gen → /game-perf → /unity-tdd → playtest |
 | `new-project-setup` | /grill-mobile → architecture → CI → security baseline → test infrastructure |
+| `mobile-flight-recorder` | End-of-session context → update `MOBILE_AGENCY_CONTEXT.md` → capture bugs, device setup, decisions, and next action |
 | `mobile-memory-workflow` | Mobile Memory: restore context → capture decisions → generate `MOBILE_MEMORY.md` → hand off across AI tools |
 | `issue-to-agent` | GitHub issue → classify → route to agents/skills → implementation and verification plan |
 | `device-proof-report` | Mobile MCP evidence → screenshots, assertions, bugs, and pass/fail proof |

--- a/cli/index.js
+++ b/cli/index.js
@@ -134,6 +134,7 @@ const WORKFLOWS = {
   'new-project-setup': { file: 'workflows/new-project-setup.md' },
   'app-launch':        { file: 'workflows/app-launch.md'        },
   'perf-sprint':       { file: 'workflows/perf-sprint.md'       },
+  'mobile-flight-recorder': { file: 'workflows/mobile-flight-recorder.md' },
   'mobile-memory-workflow':  { file: 'workflows/mobile-memory-workflow.md'  },
   'issue-to-agent':    { file: 'workflows/issue-to-agent.md'    },
   'device-proof-report': { file: 'workflows/device-proof-report.md' },

--- a/docs/core-loops.md
+++ b/docs/core-loops.md
@@ -74,7 +74,7 @@ The user should not have to manually prompt every stage. The system should stop 
 | Testing | Add unit/UI tests, run device QA, check accessibility, and verify PRD/design match. | TDD skills, `/prd-verification`, `/mobile-mcp-qa`, `/accessibility-audit` |
 | Release | Prepare CI/CD, signing, release notes, rollout, and store submission. | `@PIPELINE`, `@SCRIBE`, `/release-prep` |
 | Growth | Improve store listing, ASO, screenshots, conversion, and monetization copy. | `@LAUNCHPAD`, `/store-listing` |
-| Maintenance | Triage crashes, preserve context, plan issue work, and prevent regressions. | `@CRASHER`, Mobile Memory, crash triage, issue-to-agent workflow |
+| Maintenance | Triage crashes, preserve context, plan issue work, and prevent regressions. | `@CRASHER`, Mobile Memory, Mobile Flight Recorder, crash triage, issue-to-agent workflow |
 
 ## Platform Plugins
 
@@ -138,7 +138,6 @@ The model is intentionally ahead of the full implementation. The strongest next 
 
 - Loop Engineering automation to reduce manual prompting
 - `/prd-verification` rollout into Mobile Harness and APPFORGE evidence gates
-- Mobile Flight Recorder
 - Device Proof Reports
 - dedicated Security Audit Loop reports
 - Kotlin Multiplatform plugin assets

--- a/docs/index.html
+++ b/docs/index.html
@@ -337,7 +337,7 @@
   <div class="stats">
     <div class="stat"><div class="stat-num">19</div><div class="stat-label">Agents</div></div>
     <div class="stat"><div class="stat-num">35</div><div class="stat-label">Skills</div></div>
-    <div class="stat"><div class="stat-num">15</div><div class="stat-label">Workflows</div></div>
+    <div class="stat"><div class="stat-num">16</div><div class="stat-label">Workflows</div></div>
     <div class="stat"><div class="stat-num">7</div><div class="stat-label">Plugin Tracks</div></div>
   </div>
 </div>
@@ -549,7 +549,7 @@
 <section id="workflows">
   <div class="container">
     <div class="section-label">Workflows</div>
-    <h2>15 end-to-end processes.</h2>
+    <h2>16 end-to-end processes.</h2>
     <p class="section-sub">The differentiator. No other mobile AI toolkit has these — full sequences that chain agents and skills from ticket to store.</p>
 
     <div class="workflow-list">
@@ -588,6 +588,10 @@
       <div class="workflow-item">
         <div class="workflow-name">new-project-setup</div>
         <div class="workflow-desc">/grill-mobile → architecture → CI from day one → SENTINEL baseline → test infrastructure</div>
+      </div>
+      <div class="workflow-item">
+        <div class="workflow-name">mobile-flight-recorder</div>
+        <div class="workflow-desc">End-of-session context → MOBILE_AGENCY_CONTEXT.md → bugs, device setup, decisions, and next action</div>
       </div>
       <div class="workflow-item">
         <div class="workflow-name">issue-to-agent</div>

--- a/docs/mobile-memory.md
+++ b/docs/mobile-memory.md
@@ -175,6 +175,37 @@ Read MOBILE_MEMORY.md and continue from NEXT ACTION.
 
 ---
 
+## Mobile Flight Recorder
+
+Mobile Flight Recorder is the end-of-session workflow for turning Mobile Memory into a project-level handoff file named `MOBILE_AGENCY_CONTEXT.md`.
+
+Use it when a session produced decisions, fixes, bugs, device proof, PR links, or a next task that must survive across AI tools. It records:
+
+- App goal, platform, stack, repo, and active branch
+- Architecture and implemented features
+- Current task and pending tasks
+- Known bugs, risks, and evidence
+- Test/build commands that actually ran
+- Device, emulator, simulator, or Mobile MCP setup
+- Agent findings, decisions, changed files, and links
+- Exactly one next recommended action
+
+Run it with:
+
+```text
+Run Mobile Flight Recorder. Update MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if useful. Capture decisions, files changed, tests run, known bugs, device setup, links, and exactly one Next Recommended Action. Do not include secrets.
+```
+
+Resume any AI tool with:
+
+```text
+Read MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if present. Continue from Next Recommended Action. Inspect changed files before editing and update the flight recorder before stopping.
+```
+
+Use `MOBILE_MEMORY.md` for compact memory and `MOBILE_AGENCY_CONTEXT.md` for the broader project flight recorder.
+
+---
+
 ## Graphify Integration
 
 Graphify can be used first to create a general graph of a project. Mobile Memory enhances that output with mobile semantics:

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -15,10 +15,11 @@
 7. [How Skills Work](#7-how-skills-work)
 8. [How Prompts Work](#8-how-prompts-work)
 9. [Device Proof Reports](#9-device-proof-reports)
-10. [Input Format Reference](#10-input-format-reference)
-11. [Output Format Reference](#11-output-format-reference)
-12. [Contributing a New Agent](#12-contributing-a-new-agent)
-13. [FAQ](#13-faq)
+10. [Mobile Flight Recorder](#10-mobile-flight-recorder)
+11. [Input Format Reference](#11-input-format-reference)
+12. [Output Format Reference](#12-output-format-reference)
+13. [Contributing a New Agent](#13-contributing-a-new-agent)
+14. [FAQ](#14-faq)
 
 ---
 
@@ -493,7 +494,46 @@ Use the Mobile MCP evidence from this QA pass and produce DEVICE_QA_REPORT.md.
 
 ---
 
-## 10. Input Format Reference
+## 10. Mobile Flight Recorder
+
+Mobile Flight Recorder is the end-of-session workflow for preserving project context across AI tools, teammates, and long-running mobile work. It creates or updates `MOBILE_AGENCY_CONTEXT.md`, a stable project flight recorder that sits beside `MOBILE_MEMORY.md`.
+
+Run it at the end of every meaningful session, before switching tools, before tokens run out, after device QA, or before opening a PR.
+
+```text
+Run Mobile Flight Recorder. Update MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if useful. Capture decisions, files changed, tests run, known bugs, device setup, links, and exactly one Next Recommended Action. Do not include secrets.
+```
+
+### What it captures
+
+- App goal, platform, stack, repo, and active branch
+- Architecture and implemented features
+- Current task, pending tasks, known bugs, and risks
+- Test/build commands that actually ran
+- Design source and Mobile MCP/device setup
+- Agent findings, decisions, changed files, evidence, and links
+- Exactly one next recommended action
+
+### Resume prompt
+
+Use this in any AI tool:
+
+```text
+Read MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if present. Continue from Next Recommended Action. Inspect changed files before editing and update the flight recorder before stopping.
+```
+
+### How it works with Mobile Memory and MRECALL
+
+- Read `MOBILE_AGENCY_CONTEXT.md`, `MOBILE_MEMORY.md`, `MRECALL.md`, and `.mobile-ai-agents/memory/index.md` when present.
+- Use `npx mobile-ai-agents memory capture` for decisions, findings, code state, and next actions when terminal access is available.
+- Use `npx mobile-ai-agents memory checkpoint` or `/mobile-memory-save` to generate the compact `MOBILE_MEMORY.md` handoff.
+- Use `MOBILE_AGENCY_CONTEXT.md` for the broader project state and `MOBILE_MEMORY.md` for compact session continuity.
+
+See [Mobile Memory](mobile-memory.md) for the complete guide.
+
+---
+
+## 11. Input Format Reference
 
 Most agents use a consistent key-value input format:
 
@@ -518,7 +558,7 @@ MULTI_LINE_FIELD:
 
 ---
 
-## 11. Output Format Reference
+## 12. Output Format Reference
 
 ### Code Review Agents (Android, iOS)
 
@@ -631,7 +671,7 @@ Flow:
 
 ---
 
-## 12. Contributing a New Agent
+## 13. Contributing a New Agent
 
 ### Before you start
 
@@ -678,7 +718,7 @@ An agent is accepted if:
 
 ---
 
-## 13. FAQ
+## 14. FAQ
 
 **Q: Which LLM works best?**  
 A: Claude Sonnet 4.6 and GPT-4o both produce high-quality structured output for all agents. Smaller models (GPT-4o-mini, Claude Haiku) work for simpler agents (prompts, skills) but may produce less consistent structured output for complex agents (BLoC Feature Builder, CI/CD Generator).

--- a/workflows/mobile-flight-recorder.md
+++ b/workflows/mobile-flight-recorder.md
@@ -1,0 +1,225 @@
+# Workflow - Mobile Flight Recorder
+
+**Type:** Persistent project context and AI handoff  
+**Agents Used:** Mobile Memory, MOBILE-HARNESS, APPFORGE, CRASHER, PERF, SENTINEL  
+**Skills Used:** /mobile-memory-save, /mobile-memory-search, /mobile-memory-graph, /prd-verification, /mobile-mcp-qa
+
+---
+
+## When to Use
+
+Use this workflow at the end of every meaningful mobile AI session, before switching tools, before tokens run out, before handing work to another developer, after device QA, or before opening a PR.
+
+The goal is to create one durable project flight recorder that answers:
+
+- What is this app?
+- What did the agents decide?
+- What changed?
+- What is still broken?
+- What exact action should the next AI or developer take?
+
+This is the viral demo angle: before Flight Recorder, an AI session forgets the project. After Flight Recorder, any AI tool can resume from one file.
+
+---
+
+## Inputs
+
+Collect these facts from the current session, repo, issue, PR, test output, and device evidence:
+
+```text
+PROJECT:
+PLATFORM:
+STACK:
+REPO:
+CURRENT BRANCH:
+CURRENT GOAL:
+DELIVERY PROFILE:
+DESIGN SOURCE:
+DEVICE / MOBILE MCP SETUP:
+ARCHITECTURE:
+IMPLEMENTED FEATURES:
+CURRENT TASK:
+PENDING TASKS:
+KNOWN BUGS / RISKS:
+TEST AND BUILD COMMANDS:
+RECENT AGENT FINDINGS:
+DECISIONS:
+CHANGED FILES:
+EVIDENCE:
+LINKS:
+NEXT RECOMMENDED ACTION:
+```
+
+If a field is unknown, write `UNKNOWN` instead of inventing it.
+
+---
+
+## Workflow
+
+### 1. Restore Existing Context
+
+Read these files when present:
+
+```text
+MOBILE_AGENCY_CONTEXT.md
+MOBILE_MEMORY.md
+MRECALL.md
+.mobile-ai-agents/memory/index.md
+PRD.md
+DESIGN.md
+TASKS.md
+ROADMAP.md
+```
+
+Then search local memory if available:
+
+```bash
+npx mobile-ai-agents memory search "<current feature or issue>"
+npx mobile-ai-agents memory timeline --limit 20
+```
+
+Use `/mobile-memory-search` when the search output needs to be converted into confirmed context, assumptions, files to read, and the next action.
+
+### 2. Capture Session Events
+
+Save important facts into local Mobile Memory when terminal access is available:
+
+```bash
+npx mobile-ai-agents memory capture --type decision --title "<decision>" --text "<why it was chosen>"
+npx mobile-ai-agents memory capture --type finding --title "<agent finding>" --text "<risk, evidence, and status>"
+npx mobile-ai-agents memory capture --type code-state --title "<changed files>" --text "<current diff or file summary>"
+npx mobile-ai-agents memory capture --type next-action --text "<one executable next action>"
+```
+
+Do not capture secrets, customer data, private logs, tokens, credentials, signing keys, or proprietary crash payloads.
+
+### 3. Update MOBILE_AGENCY_CONTEXT.md
+
+Create or update `MOBILE_AGENCY_CONTEXT.md` with the stable schema below. Keep it concise enough to paste into any AI tool, but concrete enough that the next session does not need the user to repeat context.
+
+````markdown
+# Mobile Agency Context
+
+**Last Updated:** YYYY-MM-DD HH:mm TZ
+**Project:** <name>
+**Platform:** <Android/iOS/Flutter/React Native/KMP/Unity/Unreal>
+**Stack:** <language, framework, key libraries>
+**Repo:** <repo URL or local path>
+**Current Branch:** <branch>
+**Current Goal:** <goal>
+**Delivery Profile:** <prototype/MVP/release/hotfix>
+
+## Design Source
+<Figma link, screenshot path, PRD/design docs, or UNKNOWN>
+
+## Device / Mobile MCP Setup
+<device, emulator, simulator, app id, build variant, test account, or UNKNOWN>
+
+## Architecture
+<current architecture, module boundaries, state management, persistence, API layer>
+
+## Implemented Features
+- <feature and evidence>
+
+## Current Task
+<the work in progress>
+
+## Pending Tasks
+- <task, owner/tool if known, expected evidence>
+
+## Known Bugs / Risks
+- <bug/risk, severity, evidence, suggested fix>
+
+## Test And Build Commands
+```bash
+<commands that are known to work>
+````
+
+## Recent Agent Findings
+| Agent/Skill | Finding | Status |
+|---|---|---|
+| <name> | <finding> | <open/fixed/needs verification> |
+
+## Decisions
+| Decision | Reason | Rejected |
+|---|---|---|
+| <decision> | <reason> | <alternative> |
+
+## Changed Files
+- `<path>`: <what changed>
+
+## Evidence
+- <test output, screenshot, device proof report, PR link, issue link>
+
+## Links
+- <issue, PR, wiki, release, design>
+
+## Next Recommended Action
+<exactly one executable next step>
+
+## Resume Prompt
+Read `MOBILE_AGENCY_CONTEXT.md` and `MOBILE_MEMORY.md` if present. Continue from `Next Recommended Action`. Before editing, inspect the files listed in `Changed Files`, preserve existing user changes, and update this file before stopping.
+```
+
+### 4. Generate Mobile Memory Checkpoint
+
+When local memory has useful events, generate the portable memory file:
+
+```bash
+npx mobile-ai-agents memory checkpoint
+```
+
+When there is no local memory store or time is short, run:
+
+```text
+/mobile-memory-save
+```
+
+Use `MOBILE_MEMORY.md` for compact session continuity and `MOBILE_AGENCY_CONTEXT.md` for the broader project flight recorder.
+
+### 5. Verify The Handoff
+
+Before stopping, check:
+
+- `Next Recommended Action` is one command or one implementation step.
+- Known bugs include severity and evidence.
+- Test commands are real commands, not generic advice.
+- Device setup says exactly what was tested or says `UNKNOWN`.
+- Changed files are specific enough for review.
+- Resume prompt works in Claude Code, Cursor, Windsurf, Codex, ChatGPT, Gemini, and Copilot.
+
+---
+
+## End-of-Session Prompt
+
+Use this prompt at the end of a session:
+
+```text
+Run Mobile Flight Recorder. Update MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if useful. Capture decisions, files changed, tests run, known bugs, device setup, links, and exactly one Next Recommended Action. Do not include secrets.
+```
+
+Use this prompt to resume:
+
+```text
+Read MOBILE_AGENCY_CONTEXT.md and MOBILE_MEMORY.md if present. Continue from Next Recommended Action. Inspect changed files before editing and update the flight recorder before stopping.
+```
+
+---
+
+## Output
+
+- Updated `MOBILE_AGENCY_CONTEXT.md`
+- Optional updated `MOBILE_MEMORY.md`
+- Optional `.mobile-ai-agents/memory/` events
+- One tool-agnostic resume prompt
+- One executable next action
+
+---
+
+## Failure Modes
+
+- If the next action has multiple steps, split it and keep only the first executable step.
+- If device evidence is missing, write `UNKNOWN` and list the Mobile MCP/device command needed next.
+- If a decision has no reason, mark it `NEEDS CONFIRMATION`.
+- If a bug has no evidence, mark it as a risk instead of a confirmed bug.
+- If the file would expose secrets or private logs, redact them before saving.


### PR DESCRIPTION
## Summary

Closes #18.

- Adds the `mobile-flight-recorder` workflow for end-of-session project context handoffs.
- Defines the stable `MOBILE_AGENCY_CONTEXT.md` schema with MRECALL and Mobile Memory integration.
- Updates CLI registration, README counts, changelog, docs, and wiki source guidance.

## Validation

- `git diff --check`
- `node --check cli/index.js`
- `node cli/index.js list`
- `npm pack --dry-run`